### PR TITLE
Update sci-m model to respond to `vcpu` data

### DIFF
--- a/src/__tests__/unit/lib/sci-m/index.test.ts
+++ b/src/__tests__/unit/lib/sci-m/index.test.ts
@@ -11,9 +11,8 @@ describe('sci-m:configure test', () => {
       model.execute([
         {
           timestamp: '2021-01-01T00:00:00Z',
-          duration: 1,
+          duration: 60 * 60 * 24 * 30,
           'total-embodied-emissions': 200,
-          'time-reserved': 60 * 60 * 24 * 30,
           'expected-lifespan': 60 * 60 * 24 * 365 * 4,
           'resources-reserved': 1,
           'total-resources': 1,
@@ -22,7 +21,6 @@ describe('sci-m:configure test', () => {
           timestamp: '2021-01-01T00:00:00Z',
           'total-embodied-emissions': 200,
           duration: 60 * 60 * 24 * 30 * 2,
-          'time-reserved': 'duration',
           'expected-lifespan': 60 * 60 * 24 * 365 * 4,
           'resources-reserved': 1,
           'total-resources': 1,
@@ -31,9 +29,8 @@ describe('sci-m:configure test', () => {
     ).resolves.toStrictEqual([
       {
         timestamp: '2021-01-01T00:00:00Z',
-        duration: 1,
+        duration: 60 * 60 * 24 * 30,
         'total-embodied-emissions': 200,
-        'time-reserved': 60 * 60 * 24 * 30,
         'expected-lifespan': 60 * 60 * 24 * 365 * 4,
         'resources-reserved': 1,
         'total-resources': 1,
@@ -43,7 +40,6 @@ describe('sci-m:configure test', () => {
         timestamp: '2021-01-01T00:00:00Z',
         'total-embodied-emissions': 200,
         duration: 60 * 60 * 24 * 30 * 2,
-        'time-reserved': 'duration',
         'expected-lifespan': 60 * 60 * 24 * 365 * 4,
         'resources-reserved': 1,
         'total-resources': 1,
@@ -54,9 +50,8 @@ describe('sci-m:configure test', () => {
       model.execute([
         {
           timestamp: '2021-01-01T00:00:00Z',
-          duration: 1,
+          duration: 60 * 60 * 24 * 30,
           'total-embodied-emissions': 200,
-          'time-reserved': 60 * 60 * 24 * 30,
           'expected-lifespan': 60 * 60 * 24 * 365 * 4,
           'vcpus-allocated': 1,
           'vcpus-total': 64,
@@ -65,7 +60,6 @@ describe('sci-m:configure test', () => {
           timestamp: '2021-01-01T00:00:00Z',
           'total-embodied-emissions': 200,
           duration: 60 * 60 * 24 * 30 * 2,
-          'time-reserved': 'duration',
           'expected-lifespan': 60 * 60 * 24 * 365 * 4,
           'vcpus-allocated': 1,
           'vcpus-total': 32,
@@ -74,9 +68,8 @@ describe('sci-m:configure test', () => {
     ).resolves.toStrictEqual([
       {
         timestamp: '2021-01-01T00:00:00Z',
-        duration: 1,
+        duration: 60 * 60 * 24 * 30,
         'total-embodied-emissions': 200,
-        'time-reserved': 60 * 60 * 24 * 30,
         'expected-lifespan': 60 * 60 * 24 * 365 * 4,
         'vcpus-allocated': 1,
         'vcpus-total': 64,
@@ -86,7 +79,6 @@ describe('sci-m:configure test', () => {
         timestamp: '2021-01-01T00:00:00Z',
         'total-embodied-emissions': 200,
         duration: 60 * 60 * 24 * 30 * 2,
-        'time-reserved': 'duration',
         'expected-lifespan': 60 * 60 * 24 * 365 * 4,
         'vcpus-allocated': 1,
         'vcpus-total': 32,
@@ -97,9 +89,8 @@ describe('sci-m:configure test', () => {
       model.execute([
         {
           timestamp: '2021-01-01T00:00:00Z',
-          duration: 1,
+          duration: 60 * 60 * 24 * 30,
           'total-embodied-emissions': 200,
-          'time-reserved': 60 * 60 * 24 * 30,
           'expected-lifespan': 60 * 60 * 24 * 365 * 4,
           'resources-reserved': 1,
           'total-resources': 1,
@@ -110,7 +101,6 @@ describe('sci-m:configure test', () => {
           timestamp: '2021-01-01T00:00:00Z',
           'total-embodied-emissions': 200,
           duration: 60 * 60 * 24 * 30 * 2,
-          'time-reserved': 'duration',
           'expected-lifespan': 60 * 60 * 24 * 365 * 4,
           'resources-reserved': 1,
           'total-resources': 1,
@@ -121,9 +111,8 @@ describe('sci-m:configure test', () => {
     ).resolves.toStrictEqual([
       {
         timestamp: '2021-01-01T00:00:00Z',
-        duration: 1,
+        duration: 60 * 60 * 24 * 30,
         'total-embodied-emissions': 200,
-        'time-reserved': 60 * 60 * 24 * 30,
         'expected-lifespan': 60 * 60 * 24 * 365 * 4,
         'resources-reserved': 1,
         'total-resources': 1,
@@ -135,7 +124,6 @@ describe('sci-m:configure test', () => {
         timestamp: '2021-01-01T00:00:00Z',
         'total-embodied-emissions': 200,
         duration: 60 * 60 * 24 * 30 * 2,
-        'time-reserved': 'duration',
         'expected-lifespan': 60 * 60 * 24 * 365 * 4,
         'resources-reserved': 1,
         'total-resources': 1,
@@ -151,7 +139,6 @@ describe('sci-m:configure test', () => {
           'total-embodied-emissions': 200,
           tee: 200,
           duration: 60 * 60 * 24 * 30 * 2,
-          'time-reserved': 'duration',
           'expected-lifespan': 60 * 60 * 24 * 365 * 4,
           'resources-reserved': 1,
           'total-ressources': 1,

--- a/src/__tests__/unit/lib/sci-m/index.test.ts
+++ b/src/__tests__/unit/lib/sci-m/index.test.ts
@@ -1,9 +1,9 @@
-import {describe, expect, jest, test} from '@jest/globals';
-import {SciMModel} from '../../../../lib';
+import { describe, expect, jest, test } from '@jest/globals';
+import { SciMModel } from '../../../../lib';
 
 jest.setTimeout(30000);
 
-describe('sci-o:configure test', () => {
+describe('sci-m:configure test', () => {
   test('initialize and test', async () => {
     const model = await new SciMModel().configure({});
     expect(model).toBeInstanceOf(SciMModel);
@@ -50,6 +50,54 @@ describe('sci-o:configure test', () => {
         'embodied-carbon': 4.10958904109589 * 2,
       },
     ]);
+
+    await expect(
+      model.execute([
+        {
+          timestamp: '2021-01-01T00:00:00Z',
+          duration: 1,
+          'total-embodied-emissions': 200,
+          'time-reserved': 60 * 60 * 24 * 30,
+          'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+          'vcpus-allocated': 1,
+          'vcpus-total': 64,
+        },
+        {
+          timestamp: '2021-01-01T00:00:00Z',
+          'total-embodied-emissions': 200,
+          duration: 60 * 60 * 24 * 30 * 2,
+          'time-reserved': 'duration',
+          'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+          'vcpus-allocated': 1,
+          'vcpus-total': 32,
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        timestamp: '2021-01-01T00:00:00Z',
+        duration: 1,
+        'total-embodied-emissions': 200,
+        'time-reserved': 60 * 60 * 24 * 30,
+        'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+        'vcpus-allocated': 1,
+        'vcpus-total': 64,
+        'embodied-carbon': 0.06421232876712328,
+      },
+      {
+        timestamp: '2021-01-01T00:00:00Z',
+        'total-embodied-emissions': 200,
+        duration: 60 * 60 * 24 * 30 * 2,
+        'time-reserved': 'duration',
+        'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+        'vcpus-allocated': 1,
+        'vcpus-total': 32,
+        'embodied-carbon': 0.2568493150684931,
+      },
+    ]);
+
+
+
+
     await expect(
       model.execute([
         {

--- a/src/__tests__/unit/lib/sci-m/index.test.ts
+++ b/src/__tests__/unit/lib/sci-m/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, jest, test } from '@jest/globals';
-import { SciMModel } from '../../../../lib';
+import {describe, expect, jest, test} from '@jest/globals';
+import {SciMModel} from '../../../../lib';
 
 jest.setTimeout(30000);
 

--- a/src/__tests__/unit/lib/sci-m/index.test.ts
+++ b/src/__tests__/unit/lib/sci-m/index.test.ts
@@ -50,7 +50,6 @@ describe('sci-m:configure test', () => {
         'embodied-carbon': 4.10958904109589 * 2,
       },
     ]);
-
     await expect(
       model.execute([
         {
@@ -94,10 +93,57 @@ describe('sci-m:configure test', () => {
         'embodied-carbon': 0.2568493150684931,
       },
     ]);
-
-
-
-
+    await expect(
+      model.execute([
+        {
+          timestamp: '2021-01-01T00:00:00Z',
+          duration: 1,
+          'total-embodied-emissions': 200,
+          'time-reserved': 60 * 60 * 24 * 30,
+          'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+          'resources-reserved': 1,
+          'total-resources': 1,
+          'vcpus-allocated': 1,
+          'vcpus-total': 64,
+        },
+        {
+          timestamp: '2021-01-01T00:00:00Z',
+          'total-embodied-emissions': 200,
+          duration: 60 * 60 * 24 * 30 * 2,
+          'time-reserved': 'duration',
+          'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+          'resources-reserved': 1,
+          'total-resources': 1,
+          'vcpus-allocated': 1,
+          'vcpus-total': 32,
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        timestamp: '2021-01-01T00:00:00Z',
+        duration: 1,
+        'total-embodied-emissions': 200,
+        'time-reserved': 60 * 60 * 24 * 30,
+        'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+        'resources-reserved': 1,
+        'total-resources': 1,
+        'vcpus-allocated': 1,
+        'vcpus-total': 64,
+        'embodied-carbon': 0.06421232876712328,
+      },
+      {
+        timestamp: '2021-01-01T00:00:00Z',
+        'total-embodied-emissions': 200,
+        duration: 60 * 60 * 24 * 30 * 2,
+        'time-reserved': 'duration',
+        'expected-lifespan': 60 * 60 * 24 * 365 * 4,
+        'resources-reserved': 1,
+        'total-resources': 1,
+        'vcpus-allocated': 1,
+        'vcpus-total': 32,
+        'embodied-carbon': 0.2568493150684931,
+      },
+    ]);
     await expect(
       model.execute([
         {

--- a/src/lib/sci-m/README.md
+++ b/src/lib/sci-m/README.md
@@ -14,6 +14,8 @@ Read more on [embodied carbon](https://github.com/Green-Software-Foundation/sci/
 - `reserved-resources`: the number of resources reserved for use by the software
 - `total-resources`: the total number of resources available
 
+> Note that if you have a model pipeline that adds `vcpus-allocated` and `vcpus-total` to each observation, such as the `cloud-instance-metadata` model, those values will be used **in preference** to the given `reserved-resources` anf `total-resources` fields. 
+
 ### Inputs
 
 - `timestamp`: a timestamp for the input
@@ -37,7 +39,7 @@ Where:
 
 - `timeShare` = Time-share; the share of the total life span of the hardware reserved for use by an application.
 
-  - `timeShare` is calculated as `time-reserved/expedted-lifespan`, where:
+  - `timeShare` is calculated as `time-reserved/expected-lifespan`, where:
     - `time-reserved` = Time Reserved; the length of time the hardware is reserved for use by the software.
     - `expected-lifespan` = Expected lifespan: the length of time, in seconds, between a component's manufacture and its disposal
 

--- a/src/lib/sci-m/README.md
+++ b/src/lib/sci-m/README.md
@@ -9,7 +9,6 @@ Read more on [embodied carbon](https://github.com/Green-Software-Foundation/sci/
 ### Model config
 
 - `total-embodied-emissions`: the sum of Life Cycle Assessment (LCA) emissions for the component
-- `time-reserved`: the share of the total life span of the hardware reserved for use by an application
 - `expected-lifespan`: the length of time, in seconds, between a component's manufacture and its disposal
 - `reserved-resources`: the number of resources reserved for use by the software
 - `total-resources`: the total number of resources available
@@ -19,7 +18,7 @@ Read more on [embodied carbon](https://github.com/Green-Software-Foundation/sci/
 ### Inputs
 
 - `timestamp`: a timestamp for the input
-- `duration`: the amount of time, in seconds, that the input covers.
+- `duration`: the amount of time covered by an observation, in this context it is used as the share of the total life span of the hardware reserved for use by an application, in seconds.
 
 ## Returns
 
@@ -39,8 +38,8 @@ Where:
 
 - `timeShare` = Time-share; the share of the total life span of the hardware reserved for use by an application.
 
-  - `timeShare` is calculated as `time-reserved/expected-lifespan`, where:
-    - `time-reserved` = Time Reserved; the length of time the hardware is reserved for use by the software.
+  - `timeShare` is calculated as `duration/expected-lifespan`, where:
+    - `duration` = the length of time the hardware is reserved for use by the software.
     - `expected-lifespan` = Expected lifespan: the length of time, in seconds, between a component's manufacture and its disposal
 
 - `resourceshare` = Resource-share; the share of the total available resources of the hardware reserved for use by an application.
@@ -64,7 +63,7 @@ sciMModel.configure()
 const results = sciMModel.execute([
   {
     'total-embodied-emissions': 200, // in gCO2e for total resource units
-    'time-reserved': 60 * 60 * 24 * 30, // time reserved in seconds, can point to another field "duration"
+    'duration': 60 * 60 * 24 * 30, // time reserved in seconds, can point to another field "duration"
     'expected-lifespan': 60 * 60 * 24 * 365 * 4, // lifespan in seconds (4 years)
     'resources-reserved': 1, // resource units reserved / used
     'total-resources': 1, // total resource units available
@@ -93,7 +92,6 @@ graph:
       config:
         sci-m:
           total-embodied-emissions: 1533.120 # gCO2eq
-          time-reserved: 1 # s per hour
           expected-lifespan: 3 # 3 years in seconds
           resources-reserved: 1
           total-resources: 8

--- a/src/lib/sci-m/index.ts
+++ b/src/lib/sci-m/index.ts
@@ -105,7 +105,6 @@ export class SciMModel implements ModelPluginInterface {
           tor = input['resources-reserved'];
         }
 
-        console.log(tor, rr)
         // M = TE * (TiR/EL) * (RR/ToR)
         input['embodied-carbon'] = te * (tir / el) * (rr / tor);
       }

--- a/src/lib/sci-m/index.ts
+++ b/src/lib/sci-m/index.ts
@@ -1,6 +1,6 @@
-import {ModelPluginInterface} from '../../interfaces';
+import { ModelPluginInterface } from '../../interfaces';
 
-import {KeyValuePair} from '../../types/common';
+import { KeyValuePair } from '../../types/common';
 
 export class SciMModel implements ModelPluginInterface {
   authParams: object | undefined = undefined;
@@ -37,39 +37,27 @@ export class SciMModel implements ModelPluginInterface {
           'total-embodied-emissions is missing. Provide in gCO2e'
         );
       }
-      if (!('time-reserved' in input || 'time-reserved' in input)) {
+      if (!('time-reserved' in input)) {
         throw new Error('time-reserved is missing. Provide in seconds');
       }
-      if (!('expected-lifespan' in input || 'expected-lifespan' in input)) {
+      if (!('expected-lifespan' in input)) {
         throw new Error('expected-lifespan is missing. Provide in seconds');
       }
-      if (!('resources-reserved' in input || 'resources-reserved' in input)) {
+      if (!('resources-reserved' in input) && !('vcpus-allocated' in input)) {
         throw new Error('resources-reserved is missing. Provide as a count');
       }
-      if (!('total-resources' in input || 'total-resources' in input)) {
+      if (!('total-resources' in input) && !('vcpus-total' in input)) {
         throw new Error(
           'total-resources: total-resources is missing. Provide as a count'
         );
       }
       if (
-        ('total-embodied-emissions' in input ||
-          'total-embodied-emissions' in input) &&
-        ('time-reserved' in input || 'time-reserved' in input) &&
-        ('expected-lifespan' in input || 'expected-lifespan') &&
-        ('resources-reserved' in input || 'resources-reserved') &&
-        ('total-resources' in input || 'total-resources' in input)
+        ('total-embodied-emissions' in input) &&
+        ('time-reserved' in input) &&
+        ('expected-lifespan' in input) &&
+        ('resources-reserved' in input || 'vcpus-allocated') &&
+        ('total-resources' in input || 'vcpus-total' in input)
       ) {
-        input['total-embodied-emissions'] =
-          input['total-embodied-emissions'] ??
-          input['total-embodied-emissions'];
-        input['time-reserved'] =
-          input['time-reserved'] ?? input['time-reserved'];
-        input['expected-lifespan'] =
-          input['expected-lifespan'] ?? input['expected-lifespan'];
-        input['resources-reserved'] =
-          input['resources-reserved'] ?? input['resources-reserved'];
-        input['total-resources'] =
-          input['total-resources'] ?? input['total-resources'];
         if (typeof input['total-embodied-emissions'] === 'string') {
           te = parseFloat(input[input['total-embodied-emissions']]);
         } else if (typeof input['total-embodied-emissions'] === 'number') {
@@ -91,20 +79,33 @@ export class SciMModel implements ModelPluginInterface {
         } else {
           el = parseFloat(input['expected-lifespan']);
         }
-        if (typeof input['resources-reserved'] === 'string') {
-          rr = parseFloat(input[input['resources-reserved']]);
-        } else if (typeof input['resources-reserved'] === 'number') {
-          rr = input['resources-reserved'];
-        } else {
+        if ('vcpus-allocated' in input && typeof (input['vcpus-allocated']) == 'string') {
+          rr = parseFloat(input['vcpus-allocated'])
+        }
+        else if ('vcpus-allocated' in input && typeof (input['vcpus-allocated']) == 'number') {
+          rr = input['vcpus-allocated']
+        }
+        else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'string') {
           rr = parseFloat(input['resources-reserved']);
+        } else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'number') {
+          rr = input['resources-reserved'];
         }
-        if (typeof input['total-resources'] === 'string') {
-          tor = parseFloat(input[input['total-resources']]);
-        } else if (typeof input['total-resources'] === 'number') {
-          tor = input['total-resources'];
-        } else {
-          tor = parseFloat(input['total-resources']);
+
+        if ('vcpus-total' in input && typeof (input['vcpus-total']) == 'string') {
+          tor = parseFloat(input['vcpus-total'])
         }
+        else if ('vcpus-total' in input && typeof (input['vcpus-total']) == 'number') {
+          tor = input['vcpus-total']
+          console.log("IN HERE")
+        }
+        else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'string') {
+          tor = parseFloat(input['resources-reserved']);
+        }
+        else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'number') {
+          tor = input['resources-reserved'];
+        }
+
+        console.log(tor, rr)
         // M = TE * (TiR/EL) * (RR/ToR)
         input['embodied-carbon'] = te * (tir / el) * (rr / tor);
       }

--- a/src/lib/sci-m/index.ts
+++ b/src/lib/sci-m/index.ts
@@ -1,6 +1,6 @@
-import { ModelPluginInterface } from '../../interfaces';
+import {ModelPluginInterface} from '../../interfaces';
 
-import { KeyValuePair } from '../../types/common';
+import {KeyValuePair} from '../../types/common';
 
 export class SciMModel implements ModelPluginInterface {
   authParams: object | undefined = undefined;
@@ -52,9 +52,9 @@ export class SciMModel implements ModelPluginInterface {
         );
       }
       if (
-        ('total-embodied-emissions' in input) &&
-        ('time-reserved' in input) &&
-        ('expected-lifespan' in input) &&
+        'total-embodied-emissions' in input &&
+        'time-reserved' in input &&
+        'expected-lifespan' in input &&
         ('resources-reserved' in input || 'vcpus-allocated') &&
         ('total-resources' in input || 'vcpus-total' in input)
       ) {
@@ -79,29 +79,48 @@ export class SciMModel implements ModelPluginInterface {
         } else {
           el = parseFloat(input['expected-lifespan']);
         }
-        if ('vcpus-allocated' in input && typeof (input['vcpus-allocated']) == 'string') {
-          rr = parseFloat(input['vcpus-allocated'])
-        }
-        else if ('vcpus-allocated' in input && typeof (input['vcpus-allocated']) == 'number') {
-          rr = input['vcpus-allocated']
-        }
-        else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'string') {
+        if (
+          'vcpus-allocated' in input &&
+          typeof input['vcpus-allocated'] === 'string'
+        ) {
+          rr = parseFloat(input['vcpus-allocated']);
+        } else if (
+          'vcpus-allocated' in input &&
+          typeof input['vcpus-allocated'] === 'number'
+        ) {
+          rr = input['vcpus-allocated'];
+        } else if (
+          'resources-reserved' in input &&
+          typeof input['resources-reserved'] === 'string'
+        ) {
           rr = parseFloat(input['resources-reserved']);
-        } else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'number') {
+        } else if (
+          'resources-reserved' in input &&
+          typeof input['resources-reserved'] === 'number'
+        ) {
           rr = input['resources-reserved'];
         }
 
-        if ('vcpus-total' in input && typeof (input['vcpus-total']) == 'string') {
-          tor = parseFloat(input['vcpus-total'])
-        }
-        else if ('vcpus-total' in input && typeof (input['vcpus-total']) == 'number') {
-          tor = input['vcpus-total']
-          console.log("IN HERE")
-        }
-        else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'string') {
+        if (
+          'vcpus-total' in input &&
+          typeof input['vcpus-total'] === 'string'
+        ) {
+          tor = parseFloat(input['vcpus-total']);
+        } else if (
+          'vcpus-total' in input &&
+          typeof input['vcpus-total'] === 'number'
+        ) {
+          tor = input['vcpus-total'];
+          console.log('IN HERE');
+        } else if (
+          'resources-reserved' in input &&
+          typeof input['resources-reserved'] === 'string'
+        ) {
           tor = parseFloat(input['resources-reserved']);
-        }
-        else if ('resources-reserved' in input && typeof input['resources-reserved'] === 'number') {
+        } else if (
+          'resources-reserved' in input &&
+          typeof input['resources-reserved'] === 'number'
+        ) {
           tor = input['resources-reserved'];
         }
 

--- a/src/lib/sci-m/index.ts
+++ b/src/lib/sci-m/index.ts
@@ -37,8 +37,8 @@ export class SciMModel implements ModelPluginInterface {
           'total-embodied-emissions is missing. Provide in gCO2e'
         );
       }
-      if (!('time-reserved' in input)) {
-        throw new Error('time-reserved is missing. Provide in seconds');
+      if (!('duration' in input)) {
+        throw new Error('duration is missing. Provide in seconds');
       }
       if (!('expected-lifespan' in input)) {
         throw new Error('expected-lifespan is missing. Provide in seconds');
@@ -53,27 +53,27 @@ export class SciMModel implements ModelPluginInterface {
       }
       if (
         'total-embodied-emissions' in input &&
-        'time-reserved' in input &&
+        'duration' in input &&
         'expected-lifespan' in input &&
         ('resources-reserved' in input || 'vcpus-allocated') &&
         ('total-resources' in input || 'vcpus-total' in input)
       ) {
         if (typeof input['total-embodied-emissions'] === 'string') {
-          te = parseFloat(input[input['total-embodied-emissions']]);
+          te = parseFloat(input['total-embodied-emissions']);
         } else if (typeof input['total-embodied-emissions'] === 'number') {
           te = input['total-embodied-emissions'];
         } else {
           te = parseFloat(input['total-embodied-emissions']);
         }
-        if (typeof input['time-reserved'] === 'string') {
-          tir = parseFloat(input[input['time-reserved']]);
-        } else if (typeof input['time-reserved'] === 'number') {
-          tir = input['time-reserved'];
+        if (typeof input['duration'] === 'string') {
+          tir = parseFloat(input['duration']);
+        } else if (typeof input['duration'] === 'number') {
+          tir = input['duration'];
         } else {
-          tir = parseFloat(input['time-reserved']);
+          tir = parseFloat(input['duration']);
         }
         if (typeof input['expected-lifespan'] === 'string') {
-          el = parseFloat(input[input['expected-lifespan']]);
+          el = parseFloat(input['expected-lifespan']);
         } else if (typeof input['expected-lifespan'] === 'number') {
           el = input['expected-lifespan'];
         } else {


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request

This PR updates the sci-m model so that it uses `vcpu-allocated` and `vcpu-total` values to scale the calculated embodied carbon. 
Currently, the model only uses `resources-reserved` and `total-resources` as provided in the model config or input data. These values can still be used, however, when `vcpus-allocated` and `vcpus-total` are available they are used instead. This enables `sci-m` to respond to data arriving from the `cloud-instance-metadata` model as part of a pipeline, rather than relying on manually added data.


<!-- Make sure tests and lint pass on CI. -->

